### PR TITLE
fix: add missing attribute to plugin.xml

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin version="2">
     <id>com.igu.meteorjs</id>
     <name>Meteor JS Template</name>
-    <version>0.6.2</version>
+    <version>0.6.3</version>
     <vendor email="issam.guissouma@laposte.net">iguissouma</vendor>
 
     <description><![CDATA[
@@ -15,6 +15,10 @@
     ]]></description>
 
     <change-notes><![CDATA[
+    Version 0.6.3<br>
+      <ul>
+          <li>Add missing attribute to plugin.xml</li>
+      </ul>
     Version 0.6.2<br>
       <ul>
           <li>Add with tag livetemplate</li>
@@ -75,6 +79,7 @@
                             serviceImplementation="org.igu.meteorjs.settings.MeteorJSTemplateSettings"/>
         <projectConfigurable
                 instance="org.igu.meteorjs.settings.MeteorJSTemplateConfigurable"
+                displayName="Meteor JS Template"
                 id="settings.meteor.js.template"
                 parentId="Settings.JavaScript"
                 order="last, after settings.phonegap"/>

--- a/src/org/igu/meteorjs/MeteorJSBoilerplateModuleBuilder.java
+++ b/src/org/igu/meteorjs/MeteorJSBoilerplateModuleBuilder.java
@@ -20,11 +20,6 @@ public class MeteorJSBoilerplateModuleBuilder extends WebModuleBuilder {
     }
 
     @Override
-    public Icon getBigIcon() {
-        return MeteorJSIcons.Meteor;
-    }
-
-    @Override
     public Icon getNodeIcon() {
         return MeteorJSIcons.Meteor;
     }
@@ -48,6 +43,4 @@ public class MeteorJSBoilerplateModuleBuilder extends WebModuleBuilder {
     public String getParentGroup() {
         return "Static Web";
     }
-
-
 }

--- a/src/org/igu/meteorjs/settings/MeteorJSTemplateSettings.java
+++ b/src/org/igu/meteorjs/settings/MeteorJSTemplateSettings.java
@@ -11,7 +11,7 @@ import org.jetbrains.annotations.Nullable;
   name = "MeteorJSTemplateSettings",
   storages = {
     @Storage(
-      file = StoragePathMacros.APP_CONFIG + "/other.xml"
+      file = StoragePathMacros.NON_ROAMABLE_FILE
     )}
 )
 public class MeteorJSTemplateSettings implements PersistentStateComponent<MeteorJSTemplateSettings> {


### PR DESCRIPTION
If displayName attribute is not present, Idea will throw an error.

Some other small changes otherwise project would not compile with Java 17 (required when compiling with latest Idea libs [libs folder in idea install dir.])